### PR TITLE
Fix dependency installation and test suite.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ sentence-transformers==5.1.0
 faiss-cpu==1.12.0
 llama-cpp-python==0.3.16
 rdflib
-feat/semantic-search
 requests
 
 # Added for XAI, plotting, and new data format features
@@ -18,4 +17,3 @@ transformers
 Pillow
 matplotlib
 openpyxl
-main

--- a/src/test_guideline_service.py
+++ b/src/test_guideline_service.py
@@ -57,6 +57,8 @@ class TestGuidelineService(unittest.TestCase):
         # Mock the response from requests.get
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.content = b"dummy pdf content"
+        mock_get.return_value = mock_response
         # We need to provide PDF content. We can create a dummy PDF in memory.
         # For simplicity, we will mock the _extract_text_from_pdf call instead.
 


### PR DESCRIPTION
The `requirements.txt` file contained invalid entries (`main` and `feat/semantic-search`) that caused `pip install` to fail. These entries have been removed.

After fixing the dependency installation, a failing test was discovered in `src/test_guideline_service.py`. The test `test_load_and_index_guidelines_url` was failing because the mock for `requests.get` was not configured correctly. The test has been fixed to properly mock the response content.