### PR TITLE
Make interactive dashboard load on startup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2547,6 +2547,9 @@ class MainWindow(QMainWindow):
         self.txt_rubric = QTextEdit()
         self.txt_rubric.setVisible(False) # Not shown in main UI
 
+        # Automatically load analytics on startup
+        self._update_analytics_tab()
+
 
         
     def action_clear_all(self):


### PR DESCRIPTION
The interactive dashboard was empty on application startup, requiring the user to manually click the "Refresh Analytics" button.

This commit adds a call to `_update_analytics_tab()` at the end of the `MainWindow`'s `__init__` method in `src/main.py`. This change improves the user experience by automatically loading and displaying the analytics data when the application is launched.